### PR TITLE
Fix malformed custom_name value for Beatmaster's Eye recipe

### DIFF
--- a/data/hsj/recipe/beastmasters_eye.json
+++ b/data/hsj/recipe/beastmasters_eye.json
@@ -27,7 +27,7 @@
     "id": "minecraft:ender_eye",
     "count": 1,
     "components": {
-      "minecraft:custom_name": "[\"\",{\"text\":\"Beastmaster's Eye\",\"italic\":false}]",
+      "minecraft:custom_name": ["",{"text":"Beastmaster's Eye","italic":false}],
       "minecraft:custom_model_data": {"strings":["hsj:beastmasters_eye"]},
       "minecraft:custom_data": {"hsj_eye":true,"hsj_beastmasters":true},
       "minecraft:rarity": "epic"


### PR DESCRIPTION
This PR addresses the invalid formatting of the `minecraft:custom_name` component in the **Beastmaster's Eye** recipe output. The previous version was using a JSON string which would cause the translation to be rendered incorrectly in-game.


## Changes Made
- Replaced the `minecraft:custom_name` item component with a properly formatted JSON array.

## Testing
- Confirmed the eye now displays with the intended name and formatting.
- Confirmed the eye can still be inserted into the end portal frame.

## Screenshots
**Before Change**
![Before](https://github.com/user-attachments/assets/4066742e-e31f-46e5-9cdd-1a66345dd93e)

**Corrected Item Component Test**
![Correct Display](https://github.com/user-attachments/assets/cddf9499-c738-46fb-8ba4-e1d9d6e7b43f)

**End Portal Test**
![Eye Inserted Into Portal](https://github.com/user-attachments/assets/76a253f4-17da-4415-97dc-595c7e557d97)




